### PR TITLE
Fixed bug stdint not included on header

### DIFF
--- a/initio.c
+++ b/initio.c
@@ -15,7 +15,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <errno.h>

--- a/initio.h
+++ b/initio.h
@@ -15,6 +15,7 @@
 
 #include <wiringPi.h>
 #include <softPwm.h>
+#include <stdint.h> // Needed for int8_t
 
 // When compiling you must include the followinglibraries: pthread, wiringPi:
 // cc -o myprog myprog.c -lwiringPi -lpthread


### PR DESCRIPTION
However we could remove all together the BOOL type for stdbool (Assuming C99 support is intended).
