### PR TITLE
Fix for Pan and Tilt servo cleanup

### DIFF
--- a/initio.c
+++ b/initio.c
@@ -130,7 +130,7 @@ void initio_Cleanup()
 {
     int usedPins[13] = { L1, L2, R1, R2, wheelLeft, wheelRight, 
                          irFL, irFR, lineLeft, lineRight,
-                         sonar, servoPan, servoTilt  };
+                         sonar, servoPanPin, servoTiltPin  };
     int pin;
 
     // Stop all motors

--- a/initio.h
+++ b/initio.h
@@ -64,7 +64,9 @@
 // Define logical Servo pins for Pan/Tilt
 // (they are mapped to Port 1 pins 18 and 22)
 #define servoPan 0
+#define servoPanPin 18     
 #define servoTilt 1
+#define servoTiltPin 22
 
 
 //======================================================================


### PR DESCRIPTION
Hi Raimund

Found a little bug in the cleanup code in the initio library... the Pin assignment were wrong for the pan and tilt servos - which ended up corrupting the I2C bus... this should fix it...